### PR TITLE
chore: fixed gosec and update fiber version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/fasthttp/session/v2 v2.1.0
-	github.com/gofiber/fiber v1.10.1
+	github.com/gofiber/fiber v1.11.0
 	github.com/google/uuid v1.1.1
-	github.com/valyala/fasthttp v1.13.1
+	github.com/valyala/fasthttp v1.14.0
 )

--- a/go.sum
+++ b/go.sum
@@ -26,10 +26,10 @@ github.com/go-redis/redis/v8 v8.0.0-beta.2 h1:9S28J9QMBotgI3tGgXbX1Wk9i8QYC3Orw4
 github.com/go-redis/redis/v8 v8.0.0-beta.2/go.mod h1:o1M7JtsgfDYyv3o+gBn/jJ1LkqpnCrmil7PSppZGBak=
 github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
-github.com/gofiber/fiber v1.10.1 h1:sfxWGvNOYoK8gNciZVfJ0XS7UTPz3+Zlb/fYGWsywNY=
-github.com/gofiber/fiber v1.10.1/go.mod h1:8083zyrwS9acYIAgpYPbXPW80m57uc8WPzPF3wt1qNk=
-github.com/gofiber/utils v0.0.3 h1:nNQKfZbZAGmOHqTOYplJwwOvX1Mg/NsTjfFO4/wTGrU=
-github.com/gofiber/utils v0.0.3/go.mod h1:pacRFtghAE3UoknMOUiXh2Io/nLWSUHtQCi/3QASsOc=
+github.com/gofiber/fiber v1.11.0 h1:7mk1bOs0HQ3x3GPwmLfr4/um/MHPaj98jNFUk1jDj2M=
+github.com/gofiber/fiber v1.11.0/go.mod h1:yFeAjCJH91bgsVXSRuJ8phno0O6/PcGHvjndFw91Vxs=
+github.com/gofiber/utils v0.0.6 h1:lWuJfXQ06aFPVA2/y7lUw9ahS4TuXhbwXnxKl1D/fuY=
+github.com/gofiber/utils v0.0.6/go.mod h1:pacRFtghAE3UoknMOUiXh2Io/nLWSUHtQCi/3QASsOc=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -82,6 +82,8 @@ github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6Kllzaw
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasthttp v1.13.1 h1:Z7kVhKP9NZz+tCSY7AVhCMPPAk7b+e5fq0l/BfdTlFc=
 github.com/valyala/fasthttp v1.13.1/go.mod h1:ol1PCaL0dX20wC0htZ7sYCsvCYmrouYra0zHzaclZhE=
+github.com/valyala/fasthttp v1.14.0 h1:67bfuW9azCMwW/Jlq/C+VeihNpAuJMWkYPBig1gdi3A=
+github.com/valyala/fasthttp v1.14.0/go.mod h1:ol1PCaL0dX20wC0htZ7sYCsvCYmrouYra0zHzaclZhE=
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
 go.opentelemetry.io/otel v0.5.0 h1:tdIR1veg/z+VRJaw/6SIxz+QX3l+m+BDleYLTs+GC1g=
 go.opentelemetry.io/otel v0.5.0/go.mod h1:jzBIgIzK43Iu1BpDAXwqOd6UPsSAk+ewVZ5ofSXw4Ek=

--- a/provider/memcache/memcache.go
+++ b/provider/memcache/memcache.go
@@ -6,10 +6,10 @@
 package memcache
 
 import (
-	"fmt"
 	"time"
 
 	memcache "github.com/fasthttp/session/v2/providers/memcache"
+	utils "github.com/gofiber/session/provider"
 )
 
 // Config memcache options
@@ -44,7 +44,7 @@ func New(config ...Config) *memcache.Provider {
 		MaxIdleConns: cfg.MaxIdleConns,
 	})
 	if err != nil {
-		fmt.Errorf("session: memcache %v", err)
+		utils.ErrorProvider("memcache", err)
 	}
 	return provider
 }

--- a/provider/mysql/mysql.go
+++ b/provider/mysql/mysql.go
@@ -6,10 +6,10 @@
 package mysql
 
 import (
-	"fmt"
 	"time"
 
 	mysql "github.com/fasthttp/session/v2/providers/mysql"
+	utils "github.com/gofiber/session/provider"
 )
 
 // Config MySQL options
@@ -94,7 +94,7 @@ func New(config ...Config) *mysql.Provider {
 		ConnMaxLifetime: cfg.ConnMaxLifetime,
 	})
 	if err != nil {
-		fmt.Errorf("session: mysql %v", err)
+		utils.ErrorProvider("mysql", err)
 	}
 	return provider
 }

--- a/provider/postgres/postgres.go
+++ b/provider/postgres/postgres.go
@@ -6,10 +6,10 @@
 package postgres
 
 import (
-	"fmt"
 	"time"
 
 	postgres "github.com/fasthttp/session/v2/providers/postgre"
+	utils "github.com/gofiber/session/provider"
 )
 
 // Config Postgres options
@@ -72,7 +72,7 @@ func New(config ...Config) *postgres.Provider {
 		ConnMaxLifetime: cfg.ConnMaxLifetime,
 	})
 	if err != nil {
-		fmt.Errorf("session: postgres %v", err)
+		utils.ErrorProvider("postgres", err)
 	}
 	return provider
 }

--- a/provider/redis/redis.go
+++ b/provider/redis/redis.go
@@ -7,10 +7,10 @@ package redis
 
 import (
 	"crypto/tls"
-	"fmt"
 	"time"
 
 	"github.com/fasthttp/session/v2/providers/redis"
+	utils "github.com/gofiber/session/provider"
 )
 
 // Config Redis options
@@ -77,7 +77,7 @@ func New(config ...Config) *redis.Provider {
 		// Limiter             cfg.Limiter,
 	})
 	if err != nil {
-		fmt.Errorf("session: redis %v", err)
+		utils.ErrorProvider("redis", err)
 	}
 	return provider
 }

--- a/provider/sqlite3/sqlite3.go
+++ b/provider/sqlite3/sqlite3.go
@@ -6,10 +6,10 @@
 package sqlite3
 
 import (
-	"fmt"
 	"time"
 
 	sqlite3 "github.com/fasthttp/session/v2/providers/sqlite3"
+	utils "github.com/gofiber/session/provider"
 )
 
 // Config redis options
@@ -50,7 +50,7 @@ func New(config ...Config) *sqlite3.Provider {
 		ConnMaxLifetime: cfg.ConnMaxLifetime,
 	})
 	if err != nil {
-		fmt.Errorf("session: sqlite3 %v", err)
+		utils.ErrorProvider("sqlite3", err)
 	}
 	return provider
 }

--- a/provider/utils.go
+++ b/provider/utils.go
@@ -1,0 +1,13 @@
+package provider
+
+import (
+	"fmt"
+	"log"
+)
+
+// ErrorProvider ...
+func ErrorProvider(provider string, err error) {
+	if e := fmt.Errorf("session: %v %v", provider, err); e != nil {
+		log.Printf("session error: %v; provider: %v;", e, provider)
+	}
+}

--- a/store.go
+++ b/store.go
@@ -23,11 +23,14 @@ func (s *Store) ID() string {
 }
 
 // Save storage before response
-func (s *Store) Save() {
-	s.sess.core.Save(s.ctx.Fasthttp, s.core)
+func (s *Store) Save() error {
+	if err := s.sess.core.Save(s.ctx.Fasthttp, s.core); err != nil {
+		return err
+	}
 	if s.sess.config.noCookie {
 		s.ctx.Fasthttp.Response.Header.Del("Set-Cookie")
 	}
+	return nil
 }
 
 // Get get data by key
@@ -47,11 +50,11 @@ func (s *Store) Delete(key string) {
 
 // Destroy session and cookies
 func (s *Store) Destroy() {
-	s.sess.core.Destroy(s.ctx.Fasthttp)
+	_ = s.sess.core.Destroy(s.ctx.Fasthttp)
 }
 
 // Regenerate session id
-func (s *Store) Regenerate() {
+func (s *Store) Regenerate() error {
 	// https://github.com/fasthttp/session/blob/master/session.go#L205
-	s.sess.core.Regenerate(s.ctx.Fasthttp)
+	return s.sess.core.Regenerate(s.ctx.Fasthttp)
 }


### PR DESCRIPTION
```
[C:\Users\Unknow\Desktop\git\session\store.go:27] - G104 (CWE-703): Errors unhandled. (Confidence: HIGH, Severity: LOW)   > s.sess.core.Save(s.ctx.Fasthttp, s.core)
[C:\Users\Unknow\Desktop\git\session\store.go:50] - G104 (CWE-703): Errors unhandled. (Confidence: HIGH, Severity: LOW)   > s.sess.core.Destroy(s.ctx.Fasthttp)
[C:\Users\Unknow\Desktop\git\session\store.go:56] - G104 (CWE-703): Errors unhandled. (Confidence: HIGH, Severity: LOW)   > s.sess.core.Regenerate(s.ctx.Fasthttp) 
[C:\Users\Unknow\Desktop\git\session\provider\memcache\memcache.go:47] - G104 (CWE-703): Errors unhandled. (Confidence: HIGH, Severity: LOW) 
    > fmt.Errorf("session: memcache %v", err)
[C:\Users\Unknow\Desktop\git\session\provider\mysql\mysql.go:97] - G104 (CWE-703): Errors unhandled. (Confidence: HIGH, Severity: LOW)
    > fmt.Errorf("session: mysql %v", err)
[C:\Users\Unknow\Desktop\git\session\provider\postgres\postgres.go:75] - G104 (CWE-703): Errors unhandled. (Confidence: HIGH, Severity: LOW)
    > fmt.Errorf("session: postgres %v", err)
[C:\Users\Unknow\Desktop\git\session\provider\sqlite3\sqlite3.go:53] - G104 (CWE-703): Errors unhandled. (Confidence: HIGH, Severity: LOW)
    > fmt.Errorf("session: sqlite3 %v", err)

Summary:
Files: 8
Lines: 606
Nosec: 0
Issues: 7 
```