### PR TITLE
✨ Add error throwing for provider creations

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ import (
 func main() {
   app := fiber.New()
 
-  // create session handler
+  // create session handler, using the in-memory session store
   sessions := session.New()
 
   app.Get("/", func(c *fiber.Ctx) {
@@ -69,11 +69,10 @@ func main() {
 package main
 
 import (
-  "fmt"
-
   "github.com/gofiber/fiber"
   "github.com/gofiber/session"
   "github.com/gofiber/session/provider/memcache"
+  "log"
   // "github.com/gofiber/session/provider/mysql"
   // "github.com/gofiber/session/provider/postgres"
   // "github.com/gofiber/session/provider/redis"
@@ -83,14 +82,14 @@ import (
 func main() {
   app := fiber.New()
 
-  provider := memcache.New(memcache.Config{
+  provider, err := memcache.New(memcache.Config{
     KeyPrefix:  "session",
     ServerList: []string{
       "0.0.0.0:11211",
     },
     MaxIdleConns: 8,
   })
-  // provider := mysql.New(mysql.Config{
+  // provider, err := mysql.New(mysql.Config{
   //   Host:       "session",
   //   Port:       3306,
   //   Username:   "root",
@@ -98,7 +97,7 @@ func main() {
   //   Database:   "test",
   //   TableName:  "session",
   // })
-  // provider := postgres.New(postgres.Config{
+  // provider, err := postgres.New(postgres.Config{
   //   Host:       "session",
   //   Port:       5432,
   //   Username:   "root",
@@ -106,16 +105,20 @@ func main() {
   //   Database:   "test",
   //   TableName:  "session",
   // })
-  // provider := redis.New(redis.Config{
+  // provider, err := redis.New(redis.Config{
   //   KeyPrefix:   "session",
   //   Addr:        "127.0.0.1:6379",
   //   PoolSize:    8,
   //   IdleTimeout: 30 * time.Second,
   // })
-  // provider := sqlite3.New(sqlite3.Config{
+  // provider, err := sqlite3.New(sqlite3.Config{
   //   DBPath:     "test.db",
   //   TableName:  "session",
   // })
+
+  if err != nil {
+    log.Fatal(err.Error()) 
+  }
 
   sessions := session.New(session.Config{
     Provider: provider,

--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,7 @@ require (
 	github.com/fasthttp/session/v2 v2.2.1
 	github.com/gofiber/fiber v1.14.2
 	github.com/gofiber/utils v0.0.9
-	github.com/valyala/fasthttp v1.15.1
+	github.com/klauspost/compress v1.10.11 // indirect
+	github.com/valyala/fasthttp v1.16.0
+	golang.org/x/sys v0.0.0-20200819171115-d785dc25833f // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -68,6 +68,8 @@ github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/klauspost/compress v1.10.7 h1:7rix8v8GpI3ZBb0nSozFRgbtXKv+hOe+qfEpZqybrAg=
 github.com/klauspost/compress v1.10.7/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
+github.com/klauspost/compress v1.10.11 h1:K9z59aO18Aywg2b/WSgBaUX99mHy2BES18Cr5lBKZHk=
+github.com/klauspost/compress v1.10.11/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
@@ -108,6 +110,8 @@ github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6Kllzaw
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasthttp v1.15.1 h1:eRb5jzWhbCn/cGu3gNJMcOfPUfXgXCcQIOHjh9ajAS8=
 github.com/valyala/fasthttp v1.15.1/go.mod h1:YOKImeEosDdBPnxc0gy7INqi3m1zK6A+xl6TwOBhHCA=
+github.com/valyala/fasthttp v1.16.0 h1:9zAqOYLl8Tuy3E5R6ckzGDJ1g8+pw15oQp2iL9Jl6gQ=
+github.com/valyala/fasthttp v1.16.0/go.mod h1:YOKImeEosDdBPnxc0gy7INqi3m1zK6A+xl6TwOBhHCA=
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a h1:0R4NLDRDZX6JcmhJgXi5E4b8Wg84ihbmUKp/GvSPEzc=
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
 go.opentelemetry.io/otel v0.7.0 h1:u43jukpwqR8EsyeJOMgrsUgZwVI1e1eVw7yuzRkD1l0=
@@ -155,6 +159,8 @@ golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980 h1:OjiUf46hAmXblsZdnoSXsEUSKU8r1UEzcL5RVZ4gO9Y=
 golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200819171115-d785dc25833f h1:KJuwZVtZBVzDmEDtB2zro9CXkD9O0dpCv4o2LHbQIAw=
+golang.org/x/sys v0.0.0-20200819171115-d785dc25833f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=

--- a/provider/memcache/memcache.go
+++ b/provider/memcache/memcache.go
@@ -8,8 +8,7 @@ package memcache
 import (
 	"time"
 
-	memcache "github.com/fasthttp/session/v2/providers/memcache"
-	utils "github.com/gofiber/session/provider"
+	"github.com/fasthttp/session/v2/providers/memcache"
 )
 
 // Config memcache options
@@ -21,7 +20,7 @@ type Config struct {
 }
 
 // New ...
-func New(config ...Config) *memcache.Provider {
+func New(config ...Config) (*memcache.Provider, error) {
 	var cfg Config
 	if len(config) > 0 {
 		cfg = config[0]
@@ -43,8 +42,9 @@ func New(config ...Config) *memcache.Provider {
 		Timeout:      cfg.Timeout,
 		MaxIdleConns: cfg.MaxIdleConns,
 	})
+
 	if err != nil {
-		utils.ErrorProvider("memcache", err)
+		return nil, err
 	}
-	return provider
+	return provider, nil
 }

--- a/provider/mysql/mysql.go
+++ b/provider/mysql/mysql.go
@@ -8,8 +8,7 @@ package mysql
 import (
 	"time"
 
-	mysql "github.com/fasthttp/session/v2/providers/mysql"
-	utils "github.com/gofiber/session/provider"
+	"github.com/fasthttp/session/v2/providers/mysql"
 )
 
 // Config MySQL options
@@ -20,6 +19,7 @@ type Config struct {
 	Password  string
 	Database  string
 	TableName string
+	DropTable bool
 
 	Charset         string
 	Collation       string
@@ -32,7 +32,7 @@ type Config struct {
 }
 
 // New ...
-func New(config ...Config) *mysql.Provider {
+func New(config ...Config) (*mysql.Provider, error) {
 	var cfg Config
 	if len(config) > 0 {
 		cfg = config[0]
@@ -84,6 +84,7 @@ func New(config ...Config) *mysql.Provider {
 		Password:        cfg.Password,
 		Database:        cfg.Database,
 		TableName:       cfg.TableName,
+		DropTable:       cfg.DropTable,
 		Charset:         cfg.Charset,
 		Collation:       cfg.Collation,
 		Timeout:         cfg.Timeout,
@@ -93,8 +94,9 @@ func New(config ...Config) *mysql.Provider {
 		MaxOpenConns:    cfg.MaxOpenConns,
 		ConnMaxLifetime: cfg.ConnMaxLifetime,
 	})
+
 	if err != nil {
-		utils.ErrorProvider("mysql", err)
+		return nil, err
 	}
-	return provider
+	return provider, nil
 }

--- a/provider/postgres/postgres.go
+++ b/provider/postgres/postgres.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	postgres "github.com/fasthttp/session/v2/providers/postgre"
-	utils "github.com/gofiber/session/provider"
 )
 
 // Config Postgres options
@@ -20,6 +19,7 @@ type Config struct {
 	Password        string
 	Database        string
 	TableName       string
+	DropTable       bool
 	Timeout         time.Duration
 	MaxIdleConns    int
 	MaxOpenConns    int
@@ -27,7 +27,7 @@ type Config struct {
 }
 
 // New ...
-func New(config ...Config) *postgres.Provider {
+func New(config ...Config) (*postgres.Provider, error) {
 	var cfg Config
 	if len(config) > 0 {
 		cfg = config[0]
@@ -66,13 +66,15 @@ func New(config ...Config) *postgres.Provider {
 		Password:        cfg.Password,
 		Database:        cfg.Database,
 		TableName:       cfg.TableName,
+		DropTable:       cfg.DropTable,
 		Timeout:         cfg.Timeout,
 		MaxIdleConns:    cfg.MaxIdleConns,
 		MaxOpenConns:    cfg.MaxOpenConns,
 		ConnMaxLifetime: cfg.ConnMaxLifetime,
 	})
+
 	if err != nil {
-		utils.ErrorProvider("postgres", err)
+		return nil, err
 	}
-	return provider
+	return provider, nil
 }

--- a/provider/redis/redis.go
+++ b/provider/redis/redis.go
@@ -7,10 +7,10 @@ package redis
 
 import (
 	"crypto/tls"
+	goredis "github.com/go-redis/redis/v8"
 	"time"
 
 	"github.com/fasthttp/session/v2/providers/redis"
-	utils "github.com/gofiber/session/provider"
 )
 
 // Config Redis options
@@ -33,11 +33,11 @@ type Config struct {
 	IdleTimeout        time.Duration
 	IdleCheckFrequency time.Duration
 	TLSConfig          *tls.Config
-	// Limiter            redis.Limiter
+	Limiter            goredis.Limiter
 }
 
 // New ...
-func New(config ...Config) *redis.Provider {
+func New(config ...Config) (*redis.Provider, error) {
 	var cfg Config
 	if len(config) > 0 {
 		cfg = config[0]
@@ -46,7 +46,7 @@ func New(config ...Config) *redis.Provider {
 		cfg.KeyPrefix = "session"
 	}
 	if cfg.Addr == "" {
-		cfg.Addr = "127.0.0.1:6379"
+		cfg.Addr = "localhost:6379"
 	}
 	if cfg.PoolSize == 0 {
 		cfg.PoolSize = 8
@@ -74,10 +74,11 @@ func New(config ...Config) *redis.Provider {
 		IdleTimeout:        cfg.IdleTimeout,
 		IdleCheckFrequency: cfg.IdleCheckFrequency,
 		TLSConfig:          cfg.TLSConfig,
-		// Limiter             cfg.Limiter,
+		Limiter:            cfg.Limiter,
 	})
+
 	if err != nil {
-		utils.ErrorProvider("redis", err)
+		return nil, err
 	}
-	return provider
+	return provider, nil
 }

--- a/provider/sqlite3/sqlite3.go
+++ b/provider/sqlite3/sqlite3.go
@@ -8,21 +8,21 @@ package sqlite3
 import (
 	"time"
 
-	sqlite3 "github.com/fasthttp/session/v2/providers/sqlite3"
-	utils "github.com/gofiber/session/provider"
+	"github.com/fasthttp/session/v2/providers/sqlite3"
 )
 
 // Config redis options
 type Config struct {
 	DBPath          string
 	TableName       string
+	DropTable       bool
 	MaxIdleConns    int
 	MaxOpenConns    int
 	ConnMaxLifetime time.Duration
 }
 
 // New ...
-func New(config ...Config) *sqlite3.Provider {
+func New(config ...Config) (*sqlite3.Provider, error) {
 	var cfg Config
 	if len(config) > 0 {
 		cfg = config[0]
@@ -45,12 +45,14 @@ func New(config ...Config) *sqlite3.Provider {
 	provider, err := sqlite3.New(sqlite3.Config{
 		DBPath:          cfg.DBPath,
 		TableName:       cfg.TableName,
+		DropTable:       cfg.DropTable,
 		MaxIdleConns:    cfg.MaxIdleConns,
 		MaxOpenConns:    cfg.MaxOpenConns,
 		ConnMaxLifetime: cfg.ConnMaxLifetime,
 	})
+
 	if err != nil {
-		utils.ErrorProvider("sqlite3", err)
+		return nil, err
 	}
-	return provider
+	return provider, err
 }


### PR DESCRIPTION
Changing default behavior from i.e.;
`provider := redis.New()`
to;
`provider, err := redis.New()`

Thus, removing the `util` error handler, providing more flexibility to the end-user.