### PR TITLE
Fix session destroy

### DIFF
--- a/store.go
+++ b/store.go
@@ -49,8 +49,8 @@ func (s *Store) Delete(key string) {
 }
 
 // Destroy session and cookies
-func (s *Store) Destroy() {
-	s.core.Reset()
+func (s *Store) Destroy() error {
+	return s.sess.core.Destroy(s.ctx.Context())
 }
 
 // Regenerate session id


### PR DESCRIPTION
Fixes a bug when calling `Destroy()` where the session is not destroyed and still persists in the database.